### PR TITLE
Feature: Deprecate

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -339,3 +339,7 @@ dotnet_naming_style.member_style.capitalization                           = pasc
 dotnet_naming_rule.members_are_pascal_case.severity                       = error
 dotnet_naming_rule.members_are_pascal_case.symbols                        = member_symbol
 dotnet_naming_rule.members_are_pascal_case.style                          = member_style
+
+# SonarAnalyzer Rules
+## S1133: Deprecated code should be removed
+dotnet_diagnostic.S1133.severity                                          = none

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
     <Product>XperienceCommunity.MCPServer</Product>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CopyDocumentationFilesFromPackages>true</CopyDocumentationFilesFromPackages>
     <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
-    <NoWarn>$(NoWarn);1591</NoWarn>
+    <NoWarn>$(NoWarn);1591;S1133</NoWarn>
     <RootNamespace>XperienceCommunity.MCPServer</RootNamespace>
 
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Description
 
-> [!IMPORTANT]
+> [!WARNING]
 > This package has been deprecated. Use the following native Xperience by Kentico AI capabilities instead:
 >
 > - [Content type management API + MCP server](https://docs.kentico.com/x/management_api_xp)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
 
 ## Description
 
+> [!IMPORTANT]
+> This package has been deprecated. Use the following native Xperience by Kentico AI capabilities instead:
+>
+> - [Content type management API + MCP server](https://docs.kentico.com/x/management_api_xp)
+> - [Documentation MCP server](https://docs.kentico.com/x/mcp_server_xp)
+> - [Content Modeling MCP Server](https://docs.kentico.com/x/content_modeling_mcp_guides)
+
 An [MCP Server](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) built with the [.NET MCP Server SDK](https://github.com/modelcontextprotocol/csharp-sdk) tailored for Xperience by Kentico projects and installed as a NuGet package.
 
 Why use this library? By exposing a discrete set of documented tools to [an AI agent](https://code.visualstudio.com/blogs/2025/02/24/introducing-copilot-agent-mode) in an Xperience by Kentico project, that agent has more well structured context and capabilities. This means it can be a better copilot to developers building features for marketers using Xperience by Kentico.
@@ -27,7 +34,7 @@ For a more detailed explanation of this project, read the blog post _[Turn your 
 
 | Xperience Version | Library Version |
 | ----------------- | --------------- |
-| >= 30.6.1         | 2.0.0           |
+| >= 30.6.1         | 2.0.x           |
 | >= 30.4.1         | 1.0.0           |
 
 ### Dependencies

--- a/src/XperienceCommunity.MCPServer/ServiceCollectionExtensions.cs
+++ b/src/XperienceCommunity.MCPServer/ServiceCollectionExtensions.cs
@@ -20,20 +20,22 @@ public static class ServiceCollectionExtensions
     };
 
     /// <summary>
-    /// 
+    /// Adds MCP server services to the service collection.
     /// </summary>
-    /// <param name="services"></param>
-    /// <returns></returns>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    [Obsolete("XperienceCommunity.MCPServer is deprecated. Use Xperience by Kentico's native Content type management API + MCP server (https://docs.kentico.com/x/management_api_xp) and Documentation MCP server (https://docs.kentico.com/x/mcp_server_xp) instead.")]
     public static IServiceCollection AddXperienceMCPServer(this IServiceCollection services) =>
         services
             .AddXperienceMCPServer(options => { });
 
     /// <summary>
-    /// 
+    /// Adds MCP server services to the service collection with configuration.
     /// </summary>
-    /// <param name="services"></param>
-    /// <param name="configureOptions"></param>
-    /// <returns></returns>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">Configuration action.</param>
+    /// <returns>The service collection for chaining.</returns>
+    [Obsolete("XperienceCommunity.MCPServer is deprecated. Use Xperience by Kentico's native Content type management API + MCP server (https://docs.kentico.com/x/management_api_xp) and Documentation MCP server (https://docs.kentico.com/x/mcp_server_xp) instead.")]
     public static IServiceCollection AddXperienceMCPServer(
      this IServiceCollection services,
      Action<XperienceMCPServerConfiguration> configureOptions)
@@ -60,10 +62,11 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    /// 
+    /// Configures the MCP server endpoint.
     /// </summary>
-    /// <param name="app"></param>
-    /// <returns></returns>
+    /// <param name="app">The web application.</param>
+    /// <returns>The application builder for chaining.</returns>
+    [Obsolete("XperienceCommunity.MCPServer is deprecated. Use Xperience by Kentico's native Content type management API + MCP server (https://docs.kentico.com/x/management_api_xp) and Documentation MCP server (https://docs.kentico.com/x/mcp_server_xp) instead.")]
     public static IApplicationBuilder UseXperienceMCPServer(this WebApplication app)
     {
         var options = app.Services

--- a/src/XperienceCommunity.MCPServer/XperienceCommunity.MCPServer.csproj
+++ b/src/XperienceCommunity.MCPServer/XperienceCommunity.MCPServer.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Model Context Protocol (MCP) server integration for Xperience by Kentico applications</Description>
+    <Description>[DEPRECATED] Model Context Protocol (MCP) server integration for Xperience by Kentico applications. This package is deprecated in favor of native Xperience by Kentico AI capabilities.</Description>
     <NoWarn>S101</NoWarn>
   </PropertyGroup>
+
+  <Target Name="XperienceMCPServerDeprecationWarning" BeforeTargets="CoreCompile">
+    <Warning Text="XperienceCommunity.MCPServer is deprecated and will no longer receive updates. Please migrate to Xperience by Kentico's native AI capabilities." />
+  </Target>
 
   <ItemGroup>
     <PackageReference Include="Kentico.Xperience.WebApp" />


### PR DESCRIPTION
This pull request deprecates the `XperienceCommunity.MCPServer` package in favor of native Xperience by Kentico AI capabilities. It updates documentation, code comments, and metadata to reflect the deprecation, and introduces compile-time warnings to alert users. No functional changes to the package's runtime behavior are included.

**Deprecation notices and guidance:**

* Updated the `README.md` with a prominent deprecation warning and links to recommended native alternatives.
* Marked all public extension methods in `ServiceCollectionExtensions.cs` as `[Obsolete]` with messages directing users to native solutions. [[1]](diffhunk://#diff-a66c955158f95d0c4aa9f594ded02da0cefae344c5aee556e157fcc9d75d6d74L23-R38) [[2]](diffhunk://#diff-a66c955158f95d0c4aa9f594ded02da0cefae344c5aee556e157fcc9d75d6d74L63-R69)
* Changed the NuGet package description in `XperienceCommunity.MCPServer.csproj` to indicate deprecation and recommend migration.
* Added a build warning in the project file to inform users at compile time about the deprecation and migration path.

**Versioning and documentation updates:**

* Bumped the version prefix to `2.0.1` and updated the compatibility table in the `README.md` to use `2.0.x` for clarity. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL9-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R37)